### PR TITLE
fix: correct loop to print affirmation 50 times instead of 51

### DIFF
--- a/4-loops/18-affirmations.java
+++ b/4-loops/18-affirmations.java
@@ -1,7 +1,7 @@
 public class HelloWorld {
     public static void main(String[] args) {
         // Write your code here 💖
-        for (int i = 0; i <= 50; i++) {
+        for (int i = 0; i < 50; i++) {
             System.out.println("I will be great at programming! 🚀");
         }
     }


### PR DESCRIPTION
This commit addresses an off-by-one error in the loop condition within 18-affirmations.java.
The original loop used i <= 50, resulting in 51 iterations due to zero-based indexing (i starting at 0).
By updating the condition to i < 50, the loop executes exactly 50 times, aligning with the intended behavior of printing the affirmation fifty times.

This correction enhances the accuracy of the program and ensures compliance with the exercise requirements.

