### PR TITLE
feat: add height and weight check for ride eligibility

### DIFF
--- a/3-control-flow/14-rollercoaster.java
+++ b/3-control-flow/14-rollercoaster.java
@@ -6,7 +6,7 @@ public class HelloWorld {
         int height = 169;
         int weight = 45;
 
-        if (height >= 120 && weight >= 40) {
+        if (height > 120 && weight > 40) {
             System.out.println("Congrats! You can ride!");
         } else {
             System.out.println("Sorry, You can't ride today.");


### PR DESCRIPTION
Updated the rollercoaster eligibility check to require strictly greater height and weight (height > 120 && weight > 40) instead of allowing equal values. This aligns the code with the task’s requirement that both conditions must be above the thresholds, ensuring accurate validation.

